### PR TITLE
feat: gitconfigにdelete-branchesのaliasを追加

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -7,6 +7,6 @@
 	br = branch
 	cz = "git-cz" # https://github.com/streamich/git-cz で 統一した commit メッセージで commit を作成する.
 	delete-features = "!git br | grep 'feature/' | xargs git br -D" # 今いるブランチ以外の feature ブランチを全部削除する.
-
+	delete-branches = "!git branch | grep -v -e 'main' -e 'master' | xargs git branch -D"  # 今いるブランチと main 以外のブランチを全部削除する.
 [init]
     defaultBranch = main


### PR DESCRIPTION
delete-features だけでなく、develop や release ブランチも削除したいとき用。