### PR TITLE
fix(asdf): Flutterが見つからない不具合を修正

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -33,6 +33,9 @@ ENABLE_PERFORMANCE_MEASUREMENT='TRUE' # 'TRUE' || 'FALSE'
   # export PATH="$PATH:/Users/apple/develop/flutter/bin"
   # # fvm
   # export PATH="$PATH:$HOME/.pub-cache/bin"
+  # asdf-flutter の為に FLUTTER_ROOT を設定する
+  # @see https://github.com/oae/asdf-flutter の README
+  export FLUTTER_ROOT="$(asdf where flutter)"
 
   # # android path 追加
   # export PATH=$PATH:/Users/apple/Library/Android/sdk/platform-tools


### PR DESCRIPTION
asdf-flutterのREADMEに記載されている環境変数の追加をしてなかった為、VScode で見つからなかったり、Xcode の Run Script が上手くいかない原因になっていた。
README 通りに 環境変数を指定する。