### PR TITLE
docs: install コマンドを更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $HOME 配下に格納される 設定ファイル群 の git 管理。
 以下を実行する
 
 ```
-bash -c "$( curl -fsSL https://raw.github.com/ken-ty/dotfiles/master/install.sh )"
+bash -c "$( curl -fsSL https://raw.github.com/ken-ty/dotfiles/main/install.sh )"
 ```
 
 TODO: 各ファイルの機能や使用方法についてのドキュメントも作成する。


### PR DESCRIPTION
master → main に変更した。

master だと main の更新が linux ですぐに反映されなかった。キャッシュのせい？
path変えたら治ったので、一時対応として。またキャッシュ問題発生したら根本原因違う気がする。